### PR TITLE
Refactor router config, use urlForName

### DIFF
--- a/src/components/app-index.ts
+++ b/src/components/app-index.ts
@@ -8,6 +8,7 @@
 import { LitElement, html, css, customElement, query } from 'lit-element';
 
 import { config } from '../config';
+import { attachRouter, urlForName } from '../router';
 
 import 'pwa-helper-components/pwa-install-button.js';
 import 'pwa-helper-components/pwa-update-available.js';
@@ -55,9 +56,9 @@ export class AppIndex extends LitElement {
     return html`
       <header>
         <nav>
-          <a href="/">Home</a>
+          <a href="${urlForName('home')}">Home</a>
           <span>-</span>
-          <a href="/about">About</a>
+          <a href="${urlForName('about')}">About</a>
         </nav>
 
         <pwa-install-button>
@@ -78,13 +79,7 @@ export class AppIndex extends LitElement {
     `;
   }
 
-  private async initializeRouter() {
-    const router = await import('../router/index');
-
-    router.init(this.main);
-  }
-
   firstUpdated() {
-    this.initializeRouter();
+    attachRouter(this.main);
   }
 }

--- a/src/pages/page-not-found.ts
+++ b/src/pages/page-not-found.ts
@@ -8,6 +8,8 @@
 import { html, css, customElement } from 'lit-element';
 import { setMetaTag, removeMetaTag } from '../helpers/html-meta-manager/utils';
 
+import { urlForName } from '../router';
+
 import { PageElement } from '../helpers/page-element';
 
 @customElement('page-not-found')
@@ -26,7 +28,7 @@ export class PageNotFound extends PageElement {
         <h1>Page not found</h1>
 
         <p>
-          <a href="/">Back to home</a>
+          <a href="${urlForName('home')}">Back to home</a>
         </p>
       </section>
     `;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,18 +9,24 @@ import { Router } from '@vaadin/router';
 
 import { routes } from './routes';
 
-export const init = (outlet: HTMLElement) => {
-  const router = new Router(outlet);
+const router = new Router();
 
-  router.setRoutes([
-    // Redirect to URL without trailing slash
-    {
-      path: '(.*)/',
-      action: (context, commands) => {
-        const newPath = context.pathname.slice(0, -1);
-        return commands.redirect(newPath);
-      }
-    },
-    ...routes
-  ]);
+router.setRoutes([
+  // Redirect to URL without trailing slash
+  {
+    path: '(.*)/',
+    action: (context, commands) => {
+      const newPath = context.pathname.slice(0, -1);
+      return commands.redirect(newPath);
+    }
+  },
+  ...routes
+]);
+
+export const attachRouter = (outlet: HTMLElement) => {
+  router.setOutlet(outlet);
+};
+
+export const urlForName = (name: string) => {
+  return router.urlForName(name);
 };


### PR DESCRIPTION
Fixes #10 

This addresses the following problem:

> We can't import the router instance to use the router helpers.

The solution demonstrated in this PR looks like this:

- create router instance and call `setRoutes` eagerly
- defer setting outlet until `app-index` is rendered: