### PR TITLE
Fix Rollup warnings

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,7 @@
 {
   "plugins": [
     ["@babel/plugin-proposal-class-properties", { "loose": true }],
+    ["@babel/plugin-proposal-private-methods", { "loose": true }],
     ["@babel/plugin-proposal-decorators", { "decoratorsBeforeExport": true }]
   ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,15 +53,21 @@ const config = merge(
         inlineSources: false
       }),
       replace({
-        'process.env.NODE_ENV': JSON.stringify('production')
+        preventAssignment: true,
+        values: {
+          'process.env.NODE_ENV': JSON.stringify('production')
+        }
       }),
       ...(process.env.NODE_ENV
         ? [
             replace({
+              preventAssignment: true,
               include: 'src/**/*.ts',
               exclude: 'src/config.*.ts',
               delimiters: ['', ''],
-              './config': `./config.${process.env.NODE_ENV}`
+              values: {
+                './config': `./config.${process.env.NODE_ENV}`
+              }
             })
           ]
         : []),

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -17,10 +17,13 @@ export default {
     ...(process.env.NODE_ENV
       ? [
           fromRollup(replace)({
+            preventAssignment: true,
             include: 'src/**/*.ts',
             exclude: 'src/config.*.ts',
             delimiters: ['', ''],
-            './config': `./config.${process.env.NODE_ENV}`
+            values: {
+              './config': `./config.${process.env.NODE_ENV}`
+            }
           })
         ]
       : [])


### PR DESCRIPTION
About babel warning:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
        ["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

About Rollup warning:

```
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
```