### PR TITLE
Use branch automerging in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,8 @@
   "extends": [
     "config:base",
     ":separateMultipleMajorReleases",
+    ":separatePatchReleases",
+    ":widenPeerDependencies",
     ":maintainLockFilesWeekly"
   ],
   "rangeStrategy": "bump",
@@ -12,11 +14,13 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "matchCurrentVersion": "!/^[~^]?0/",
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "lockFileMaintenance": {
-    "automerge": true
+    "automerge": true,
+    "automergeType": "branch"
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base",
     ":separateMultipleMajorReleases",
-    ":separatePatchReleases",
     ":maintainLockFilesWeekly"
   ],
   "rangeStrategy": "bump",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
     "config:base",
     ":separateMultipleMajorReleases",
     ":separatePatchReleases",
-    ":widenPeerDependencies",
     ":maintainLockFilesWeekly"
   ],
   "rangeStrategy": "bump",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     ":separateMultipleMajorReleases",
+    ":separatePatchReleases",
     ":maintainLockFilesWeekly"
   ],
   "rangeStrategy": "bump",
@@ -11,8 +12,13 @@
       "enabled": false
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": "!/^[~^]?0/",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "branch"
     }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, renovate/**]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Uses branch automerging in Renovate config. Closes #438.

Also adds `:widenPeerDependencies` (see https://github.com/semver/semver/issues/502#issuecomment-466501843)