### PR TITLE
Move the meta data to the component instead of with the router

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Note: If you need to add static files to the build, like the `images` folder or 
          <p>My new explore page!</p>
        `;
      }
+
+     meta() {
+       return {
+         title: 'Explore',
+         description: 'Explore page description',
+       };
+     }
    }
    ```
 
@@ -118,17 +125,13 @@ Note: If you need to add static files to the build, like the `images` folder or 
      path: '/explore',
      name: 'explore',
      component: 'page-explore',
-     meta: {
-       title: 'Explore',
-       description: 'Explore page description'
-     },
      action: async () => {
        await import('../pages/page-explore.js');
      }
    },
    ```
 
-With SEO in mind, this project offers you the `PageElement` base class to help you to deal with it; it has a `meta()` method that edits the HTML meta tags of the specific page with the `meta` property defined in the route. And if you need dynamic information, you also can override the `meta()` method.
+With SEO in mind, this project offers you the `PageElement` base class to help you to deal with it; it has a `meta()` method that edits the HTML meta tags of the specific page. You must override that method to provide the data.
 
 ### Environment configuration
 

--- a/src/helpers/page-element-not-found.ts
+++ b/src/helpers/page-element-not-found.ts
@@ -5,10 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { pageNotFoundMeta } from '../router/routes.js';
 import { updateMeta } from './html-meta-manager/index.js';
 import { setMetaTag, removeMetaTag } from './html-meta-manager/utils.js';
 import { PageElement } from './page-element.js';
+
+export const pageNotFoundMeta = {
+  title: 'Error: Page not found',
+  description: null,
+  image: null,
+};
 
 export class PageElementNotFound extends PageElement {
   connectedCallback() {

--- a/src/helpers/page-element.ts
+++ b/src/helpers/page-element.ts
@@ -5,24 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { Route, RouterLocation } from '@vaadin/router';
-import { LitElement, property } from 'lit-element';
+import type { RouterLocation } from '@vaadin/router';
+import { LitElement, state } from 'lit-element';
 import type { PropertyValues } from 'lit-element';
 
 import config from '../config.js';
 import { updateMeta } from './html-meta-manager/index.js';
 import type { MetaOptions } from './html-meta-manager/index.js';
 
-// Add meta options to the @vaadin/router BaseRoute
-declare module '@vaadin/router/dist/vaadin-router' {
-  export interface BaseRoute {
-    meta?: MetaOptions;
-  }
-}
-
 export class PageElement extends LitElement {
-  @property({ type: Object })
-  location?: RouterLocation;
+  @state()
+  protected location?: RouterLocation;
 
   private defaultTitleTemplate = `%s | ${config.appName}`;
 
@@ -34,25 +27,25 @@ export class PageElement extends LitElement {
   }
 
   /**
-   * The page can override this method to customize the meta
+   * The page must override this method to customize the meta
    */
-  protected meta(route: Route) {
-    return route.meta;
+  protected meta(): MetaOptions | undefined {
+    return;
   }
 
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
 
-    if (this.location?.route) {
-      const meta = this.meta(this.location.route);
+    const meta = this.meta();
 
-      if (meta) {
-        updateMeta({
-          ...this.defaultMeta,
-          ...(meta.titleTemplate && { titleTemplate: meta.titleTemplate }),
-          ...meta,
-        });
-      }
+    if (meta) {
+      updateMeta({
+        ...this.defaultMeta,
+        ...((meta.titleTemplate || meta.titleTemplate === null) && {
+          titleTemplate: meta.titleTemplate,
+        }),
+        ...meta,
+      });
     }
   }
 }

--- a/src/pages/page-about.ts
+++ b/src/pages/page-about.ts
@@ -31,4 +31,11 @@ export class PageAbout extends PageElement {
       </section>
     `;
   }
+
+  meta() {
+    return {
+      title: 'About',
+      description: 'About page description',
+    };
+  }
 }

--- a/src/pages/page-home.ts
+++ b/src/pages/page-home.ts
@@ -7,6 +7,7 @@
 
 import { html, css, customElement } from 'lit-element';
 
+import config from '../config.js';
 import { PageElement } from '../helpers/page-element.js';
 
 @customElement('page-home')
@@ -39,5 +40,13 @@ export class PageHome extends PageElement {
         <p>Here you can see <a href="/error">the not found page</a>.</p>
       </section>
     `;
+  }
+
+  meta() {
+    return {
+      title: config.appName,
+      titleTemplate: null,
+      description: config.appDescription,
+    };
   }
 }

--- a/src/pages/page-not-found.ts
+++ b/src/pages/page-not-found.ts
@@ -7,7 +7,10 @@
 
 import { html, css, customElement } from 'lit-element';
 
-import { PageElementNotFound } from '../helpers/page-element-not-found.js';
+import {
+  PageElementNotFound,
+  pageNotFoundMeta,
+} from '../helpers/page-element-not-found.js';
 import { urlForName } from '../router/index.js';
 
 @customElement('page-not-found')
@@ -33,5 +36,9 @@ export class PageNotFound extends PageElementNotFound {
         </p>
       </section>
     `;
+  }
+
+  meta() {
+    return pageNotFoundMeta;
   }
 }

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -7,24 +7,11 @@
 
 import type { Route } from '@vaadin/router';
 
-import config from '../config.js';
-
-export const pageNotFoundMeta = {
-  title: 'Error: Page not found',
-  description: null,
-  image: null,
-};
-
 export const routes: Route[] = [
   {
     path: '/',
     name: 'home',
     component: 'page-home',
-    meta: {
-      title: config.appName,
-      titleTemplate: null,
-      description: config.appDescription,
-    },
     action: async () => {
       await import('../pages/page-home.js');
     },
@@ -33,10 +20,6 @@ export const routes: Route[] = [
     path: '/about',
     name: 'about',
     component: 'page-about',
-    meta: {
-      title: 'About',
-      description: 'About page description',
-    },
     action: async () => {
       await import('../pages/page-about.js');
     },
@@ -45,7 +28,6 @@ export const routes: Route[] = [
     path: '(.*)',
     name: 'not-found',
     component: 'page-not-found',
-    meta: pageNotFoundMeta,
     action: async () => {
       await import('../pages/page-not-found.js');
     },


### PR DESCRIPTION
Simplify the `page-element.ts` and decoupled the router from the meta data.

And the user always adds it from the same place, the component.