### PR TITLE
Fix Service Worker generation

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,10 +41,8 @@ const config = merge(
     outputDir: DIST_PATH,
     legacyBuild: true,
     developmentMode: process.env.ROLLUP_WATCH === 'true',
-    ...(GENERATE_SERVICE_WORKER && {
-      workbox: workboxConfig,
-      injectServiceWorker: true,
-    }),
+    workbox: GENERATE_SERVICE_WORKER && workboxConfig,
+    injectServiceWorker: GENERATE_SERVICE_WORKER,
   }),
   {
     input: 'index.html',


### PR DESCRIPTION
Right now, as the `workbox` value is `true` by default in the `createSpaConfig`, we are generating the Service Worker even if we set `GENERATE_SERVICE_WORKER ` as `false`.